### PR TITLE
Add the ability to set kubectl CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,13 @@ See integrations specs for this behavior.
 The plugin accepts the following settings:
 
 * `config`: mandatory setting, a file path (relative to your repository root) containing environments configuration
-* `dry_run`: setting this value to any non emmpty string will enable plugin dry-run mode, i.e. commands will printed to screen but they won't be executed 
+* `dry_run`: setting this value to any non empty string will enable plugin dry-run mode, i.e. commands will printed to screen but they won't be executed 
 * `colors`: can be used to disable colored output from executed commands. Default is true, setting it to `false` will disable colors.
 * `logging`: logging level of plugin, default is `debug`, supported values: [any Ruby logger valid level](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html#class-Logger-label-Description)
 * `action`: action to use in plugin, one of `[deploy, tag_check]`
 * `enforce_branch_for_tag`: string, a branch name, used in `tag_check` action
 * `enforce_head`: boolean any non empty string will be considered as `true`, used in `tag_check` action 
+* `kubectl_flags`: optional, string, any additional flags to be passed to the kubectl command
 
 ## Development
 

--- a/lib/rancher_deployer.rb
+++ b/lib/rancher_deployer.rb
@@ -81,7 +81,7 @@ module RancherDeployer
         logger.info "Updating services: #{config['services']} with image '#{image_to_deploy}'"
         config['services'].each do |service|
           logger.debug "Updating service #{service}"
-          shell.run("rancher kubectl set image deployment #{service} #{service}=#{image_to_deploy}", '-n', config['namespace'])
+          shell.run("rancher kubectl set image deployment #{service} #{service}=#{image_to_deploy} #{ENV['PLUGIN_KUBECTL_FLAGS']}", '-n', config['namespace'])
         end
       end
     end


### PR DESCRIPTION
Adds an additional plugin setting called `kubectl_flags` which adds the specified string to the end of the `kubectl` command when running the plugin.